### PR TITLE
Extract serialization handlers into adapters

### DIFF
--- a/lib/rom/redis.rb
+++ b/lib/rom/redis.rb
@@ -2,8 +2,11 @@ require 'json'
 require 'redic'
 require 'rom'
 
+require_relative './redis/serialization'
+
 module ROM
   module Redis
+
     class Relation < ROM::Relation
       forward :get
 
@@ -30,7 +33,7 @@ module ROM
       def insert(object)
         with_set do |set|
           set << object
-          connection.call('SET', name, JSON.dump(set))
+          connection.call('SET', name, Serialization.dump(set))
         end
         self
       end
@@ -39,7 +42,7 @@ module ROM
       private
 
       def with_set
-        yield(JSON.load(connection.call('GET', name)))
+        yield(Serialization.load(connection.call('GET', name)))
       end
     end
 

--- a/lib/rom/redis/serialization.rb
+++ b/lib/rom/redis/serialization.rb
@@ -1,0 +1,54 @@
+module ROM
+  module Redis
+    module Serialization
+      extend self
+
+      @adapters = {}
+      @default_adapter = :json_native
+
+      def register(name, adapter)
+        @adapters[name] = adapter
+      end
+
+      def unregister(name)
+        @adapters.delete(name)
+      end
+
+      def use(name)
+        @adapters.fetch(name)
+        @default_adapter = name
+      end
+
+      def using(name, adapter = nil)
+        default_adapter = @default_adapter
+        register(name, adapter || @adapters[name])
+        use(name)
+
+        yield
+      ensure
+        @default_adapter = default_adapter
+      end
+
+      def adapter
+        @adapters[@default_adapter]
+      end
+
+      def dump(set)
+        adapter.dump(set)
+      end
+
+      def load(set)
+        adapter.load(set)
+      end
+
+      module JSONNative
+        extend self
+
+        def dump(set) JSON.dump(set) end
+        def load(set) JSON.load(set) end
+
+        ROM::Redis::Serialization.register(:json_native, self)
+      end
+    end
+  end
+end

--- a/spec/unit/serialization_spec.rb
+++ b/spec/unit/serialization_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe ROM::Redis::Serialization do
+  module AdapterStub
+    extend self
+
+    @registered_dumps = []
+    @registered_loads = []
+
+    def registered_dumps; @registered_dumps; end
+    def registered_loads; @registered_loads; end
+
+    def load(set)
+      @registered_loads << set
+      :load
+    end
+
+    def dump(set)
+      @registered_dumps << set
+      :dump
+    end
+
+    ROM::Redis::Serialization.register(:adapter_stub, self)
+  end
+
+  describe "adapter registration" do
+    it "registers the adapter correctly" do
+      described_class.using(:adapter_stub) do
+        expect(described_class.adapter).to eq AdapterStub
+      end
+    end
+  end
+
+  describe "adapter usage" do
+    it "loads data" do
+      described_class.using(:adapter_stub) do
+        expect { described_class.load('foobar') }
+          .to change { AdapterStub.registered_loads }
+          .from([]).to(['foobar'])
+      end
+    end
+
+    it "dumps data" do
+      described_class.using(:adapter_stub) do
+        expect { described_class.dump('foobar') }
+          .to change { AdapterStub.registered_dumps }
+          .from([]).to(['foobar'])
+      end
+    end
+  end
+
+  if defined? JSON
+    describe ROM::Redis::Serialization::JSONNative do
+      describe ".dump" do
+        it "dumps the object using JSON" do
+          expect(described_class.dump(foo: "bar")).to eq %({"foo":"bar"})
+        end
+      end
+
+      describe ".load" do
+        it "loads the object using JSON" do
+          expect(described_class.load(%({"foo":"bar"}))).to eq("foo" => "bar")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
That way the user can choose which adapter to use to serialize and unserialize the data.

Right now only JSON support was added.
